### PR TITLE
Error is thrown on new tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
     - id: release
       uses: pozetroninc/github-action-get-latest-release@master
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
     # zip the file
     - name: Create Zip Folder


### PR DESCRIPTION
The current version could not be found as this is a private repo, using the user's GitHub token to get the current version (tag)